### PR TITLE
Increase karma-requirejs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "karma-chrome-launcher": "~0.1.0",
     "karma-firefox-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
-    "karma-requirejs": "~0.1.0",
+    "karma-requirejs": "~0.2.0",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",
     "karma-script-launcher": "~0.1.0"


### PR DESCRIPTION
Running into this error

```
npm ERR! peerinvalid The package karma-requirejs does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer karma@0.10.10 wants karma-requirejs@~0.2.0

```
