### PR TITLE
update dependencies; fix #303 & #304

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "repository": "https://github.com/angular/angular-phonecat",
   "license": "MIT",
   "devDependencies": {
-    "karma": "^0.12.16",
+    "karma": "^0.13.21",
     "karma-chrome-launcher": "^0.1.4",
     "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "~0.1.0",
     "protractor": "^2.1.0",
-    "http-server": "^0.6.1",
+    "http-server": "^0.9.0",
     "tmp": "0.0.23",
     "bower": "^1.3.1",
     "shelljs": "^0.2.6"


### PR DESCRIPTION
In non-English Windows http-server throws the error about invalid characters in headers. In 0.9.0 guys from http-server fixed this bug. Check out this [issue #244](https://github.com/indexzero/http-server/issues/244).

So I've updated http-server version and karma version too, because they fixed similar errors.